### PR TITLE
Allow configuration by encapsulation of the code in functions or macros

### DIFF
--- a/Assets.cmake
+++ b/Assets.cmake
@@ -1,10 +1,29 @@
-# HEADS UP: Pamplejuce assumes anything you stick in the assets folder you want to included in your binary!
+include_guard()
+
+#
+# Define a binary data target for a JUCE application using the given ASSETS
+# pjuce_add_assets(target [ASSETS glob1 glob2 ...])
+#
+# e.g.
+# pjuce_add_assets(Assets ASSETS assets/*)
+#
+# By default, if no ASSETS are provided, we assume that all the files in the `assets` folder should be included in your binary!
 # This makes life easy, but will bloat your binary needlessly if you include unused files
-file(GLOB_RECURSE AssetFiles CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/assets/*")
+#
+function(pjuce_add_assets target)
+    cmake_parse_arguments(_PJ "" "" "ASSETS" ${ARGN})
 
-# Setup our binary data as a target called Assets
-juce_add_binary_data(Assets SOURCES ${AssetFiles})
+    # If no files are provided, we assume the assets folder is where we want to look
+    if(NOT _PJ_ASSETS)
+        set(_PJ_ASSETS "${CMAKE_CURRENT_SOURCE_DIR}/assets/*")
+    endif()
 
-# Required for Linux happiness:
-# See https://forum.juce.com/t/loading-pytorch-model-using-binarydata/39997/2
-set_target_properties(Assets PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+    file(GLOB_RECURSE AssetFiles CONFIGURE_DEPENDS ${_PJ_ASSETS})
+
+    # Setup our binary data as a target called Assets
+    juce_add_binary_data(${target} SOURCES ${AssetFiles})
+
+    # Required for Linux happiness:
+    # See https://forum.juce.com/t/loading-pytorch-model-using-binarydata/39997/2
+    set_target_properties(${target} PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+endfunction()

--- a/Benchmarks.cmake
+++ b/Benchmarks.cmake
@@ -1,26 +1,57 @@
-file(GLOB_RECURSE BenchmarkFiles CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/benchmarks/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/Benchmarks/*.h")
+include_guard()
 
-# Organize the test source in the Tests/ folder in the IDE
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks PREFIX "" FILES ${BenchmarkFiles})
+# Define a benchmark target with the given sources and Catch2
+#
+# pjuce_add_benchmark(
+#     target
+#     [DIR dir]
+#     SOURCES <sources...>
+#     INCLUDES <includes...>
+#     DEPENDS <depends...>
+# )
+#
+# e.g.
+# pjuce_add_benchmark(
+#     Benchmarks
+#     DIR ./benchmarks
+#     SOURCES ./benchmarks/*.cpp ./benchmarks/*.h
+#     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../Source
+#     DEPENDS SharedCode
+# )
+function(pjuce_add_benchmark target)
+    set(_oneValueArgs DIR)
+    set(_multiValueArgs SOURCES INCLUDES DEPENDS)
+    cmake_parse_arguments(_PJ "" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
 
-add_executable(Benchmarks ${BenchmarkFiles})
-target_compile_features(Benchmarks PRIVATE cxx_std_20)
-catch_discover_tests(Benchmarks)
+    if (NOT _PJ_DIR)
+        set(_PJ_DIR ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks)
+    endif()
 
-# Our benchmark executable also wants to know about our plugin code...
-target_include_directories(Benchmarks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/source)
 
-# Copy over compile definitions from our plugin target so it has all the JUCEy goodness
-target_compile_definitions(Benchmarks PRIVATE $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
+    file(GLOB_RECURSE BenchmarkFiles CONFIGURE_DEPENDS ${_PJ_SOURCES})
 
-# And give tests access to our shared code
-target_link_libraries(Benchmarks PRIVATE SharedCode Catch2::Catch2WithMain)
+    # Organize the test source in the Tests/ folder in the IDE
+    source_group(TREE ${_PJ_DIR}  PREFIX "" FILES ${BenchmarkFiles})
 
-# Make an Xcode Scheme for the test executable so we can run tests in the IDE
-set_target_properties(Benchmarks PROPERTIES XCODE_GENERATE_SCHEME ON)
+    add_executable(${target} ${BenchmarkFiles})
+    target_compile_features(${target} PRIVATE cxx_std_20)
+    catch_discover_tests(${target})
 
-# When running Tests we have specific needs
-target_compile_definitions(Benchmarks PUBLIC
-    JUCE_MODAL_LOOPS_PERMITTED=1 # let us run Message Manager in tests
-    RUN_PAMPLEJUCE_TESTS=1 # also run tests in module .cpp files guarded by RUN_PAMPLEJUCE_TESTS
-)
+    # Our benchmark executable also wants to know about our plugin code...
+    target_include_directories(${target} PRIVATE ${_PJ_INCLUDES})
+
+    # Copy over compile definitions from our plugin target so it has all the JUCEy goodness
+    target_compile_definitions(${target} PRIVATE $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
+
+    # And give tests access to our shared code
+    target_link_libraries(${target} PRIVATE ${_PJ_DEPENDS} Catch2::Catch2WithMain)
+
+    # Make an Xcode Scheme for the test executable so we can run tests in the IDE
+    set_target_properties(${target} PROPERTIES XCODE_GENERATE_SCHEME ON)
+
+    # When running Tests we have specific needs
+    target_compile_definitions(${target} PUBLIC
+        JUCE_MODAL_LOOPS_PERMITTED=1 # let us run Message Manager in tests
+        RUN_PAMPLEJUCE_TESTS=1 # also run tests in module .cpp files guarded by RUN_PAMPLEJUCE_TESTS
+    )
+endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.20)
+
+include_guard()
+
+include("${CMAKE_CURRENT_LIST_DIR}/Index.cmake")

--- a/GitHubENV.cmake
+++ b/GitHubENV.cmake
@@ -1,13 +1,27 @@
-# Write some temp files to make GitHub Actions / packaging easy
+include_guard()
 
-if ((DEFINED ENV{CI}))
-    set (env_file "${PROJECT_SOURCE_DIR}/.env")
-    message ("Writing ENV file for CI: ${env_file}")
+# Write .env file is written to the root of the project inside CI for easier packaging
+# It uses the PROJECT_NAME, PRODUCT_NAME, VERSION, BUNDLE_ID, and COMPANY_NAME.
+#
+# pjuce_ci_write_env_file(
+#   PRODUCT_NAME "Your Product Name"
+#   BUNDLE_ID "com.yourcompany.${PROJECT_NAME}"
+#   COMPANY_NAME "Your Company Name"
+# )
+#
+function(pjuce_ci_write_env_file)
+    set(_oneValueArgs PRODUCT_NAME BUNDLE_ID COMPANY_NAME)
+    cmake_parse_arguments(_PJ "" "${_oneValueArgs}" "" ${ARGN})
 
-    # the first call truncates, the rest append
-    file(WRITE  "${env_file}" "PROJECT_NAME=${PROJECT_NAME}\n")
-    file(APPEND "${env_file}" "PRODUCT_NAME=${PRODUCT_NAME}\n")
-    file(APPEND "${env_file}" "VERSION=${CURRENT_VERSION}\n")
-    file(APPEND "${env_file}" "BUNDLE_ID=${BUNDLE_ID}\n")
-    file(APPEND "${env_file}" "COMPANY_NAME=${COMPANY_NAME}\n")
-endif ()
+    if ((DEFINED ENV{CI}))
+        set (env_file "${PROJECT_SOURCE_DIR}/.env")
+        message ("Writing ENV file for CI: ${env_file}")
+
+        # the first call truncates, the rest append
+        file(WRITE  "${env_file}" "PROJECT_NAME=${PROJECT_NAME}\n")
+        file(APPEND "${env_file}" "PRODUCT_NAME=${_PJ_PRODUCT_NAME}\n")
+        file(APPEND "${env_file}" "VERSION=${PROJECT_VERSION}\n")
+        file(APPEND "${env_file}" "BUNDLE_ID=${_PJ_BUNDLE_ID}\n")
+        file(APPEND "${env_file}" "COMPANY_NAME=${_PJ_COMPANY_NAME}\n")
+    endif ()
+endfunction()

--- a/Index.cmake
+++ b/Index.cmake
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.20)
+
+include_guard()
+
+include("${CMAKE_CURRENT_LIST_DIR}/Assets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Benchmarks.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/GitHubENV.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/JUCEDefaults.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/PamplejuceIPP.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/PamplejuceMacOS.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/PamplejuceVersion.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/SharedCodeDefaults.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/Tests.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/XcodePrettify.cmake")

--- a/JUCEDefaults.cmake
+++ b/JUCEDefaults.cmake
@@ -1,14 +1,22 @@
-# Adds all the module sources so they appear correctly in the IDE
-# Must be set before JUCE is added as a sub-dir (or any targets are made)
-# https://github.com/juce-framework/JUCE/commit/6b1b4cf7f6b1008db44411f2c8887d71a3348889
-set_property(GLOBAL PROPERTY USE_FOLDERS YES)
+include_guard()
 
-# Creates a /Modules directory in the IDE with the JUCE Module code
-option(JUCE_ENABLE_MODULE_SOURCE_GROUPS "Show all module sources in IDE projects" ON)
+# Add the default JUCE options
+#
+# pjuce_add_defaults()
+#
+macro(pjuce_add_defaults)
+    # Adds all the module sources so they appear correctly in the IDE
+    # Must be set before JUCE is added as a sub-dir (or any targets are made)
+    # https://github.com/juce-framework/JUCE/commit/6b1b4cf7f6b1008db44411f2c8887d71a3348889
+    set_property(GLOBAL PROPERTY USE_FOLDERS YES)
 
-# Color our warnings and errors
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-    add_compile_options(-fdiagnostics-color=always)
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-    add_compile_options(-fcolor-diagnostics)
-endif ()
+    # Creates a /Modules directory in the IDE with the JUCE Module code
+    option(JUCE_ENABLE_MODULE_SOURCE_GROUPS "Show all module sources in IDE projects" ON)
+
+    # Color our warnings and errors
+    if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        add_compile_options(-fdiagnostics-color=always)
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        add_compile_options(-fcolor-diagnostics)
+    endif ()
+endmacro()

--- a/PamplejuceIPP.cmake
+++ b/PamplejuceIPP.cmake
@@ -1,11 +1,19 @@
-# When present, use Intel IPP for performance on Windows
-if (WIN32) # Can't use MSVC here, as it won't catch Clang on Windows
-    find_package(IPP)
-    if (IPP_FOUND)
-        target_link_libraries(SharedCode INTERFACE IPP::ipps IPP::ippcore IPP::ippi IPP::ippcv)
-        message("IPP LIBRARIES FOUND")
-        target_compile_definitions(SharedCode INTERFACE PAMPLEJUCE_IPP=1)
-    else ()
-        message("IPP LIBRARIES *NOT* FOUND")
+include_guard()
+
+# Add IPP support to a target
+#
+# pjuce_link_ipp(target)
+#
+function(pjuce_link_ipp target)
+    # When present, use Intel IPP for performance on Windows
+    if (WIN32) # Can't use MSVC here, as it won't catch Clang on Windows
+        find_package(IPP)
+        if (IPP_FOUND)
+            target_link_libraries(${target} INTERFACE IPP::ipps IPP::ippcore IPP::ippi IPP::ippcv)
+            message("IPP LIBRARIES FOUND")
+            target_compile_definitions(${target} INTERFACE PAMPLEJUCE_IPP=1)
+        else ()
+            message("IPP LIBRARIES *NOT* FOUND")
+        endif ()
     endif ()
-endif ()
+endfunction()

--- a/PamplejuceMacOS.cmake
+++ b/PamplejuceMacOS.cmake
@@ -1,15 +1,22 @@
+include_guard()
 
-# This must be set before the project() call
-# see: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
-# FORCE must be set, see https://stackoverflow.com/a/44340246
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Support macOS down to High Sierra" FORCE)
+# Add macOS defaults for JUCE projects
+#
+# pjuce_add_macos_defaults()
+#
+macro(pjuce_add_macos_defaults)
+    # This must be set before the project() call
+    # see: https://cmake.org/cmake/help/latest/variable/CMAKE_OSX_DEPLOYMENT_TARGET.html
+    # FORCE must be set, see https://stackoverflow.com/a/44340246
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Support macOS down to High Sierra" FORCE)
 
-# Building universal binaries on macOS increases build time
-# This is set on CI but not during local dev
-if ((DEFINED ENV{CI}) AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
-    message("Building for Apple Silicon and x86_64")
-    set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
-endif ()
+    # Building universal binaries on macOS increases build time
+    # This is set on CI but not during local dev
+    if ((DEFINED ENV{CI}) AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
+        message("Building for Apple Silicon and x86_64")
+        set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
+    endif ()
 
-# By default we don't want Xcode schemes to be made for modules, etc
-set(CMAKE_XCODE_GENERATE_SCHEME OFF)
+    # By default we don't want Xcode schemes to be made for modules, etc
+    set(CMAKE_XCODE_GENERATE_SCHEME OFF)
+endmacro()

--- a/PamplejuceVersion.cmake
+++ b/PamplejuceVersion.cmake
@@ -1,9 +1,30 @@
-# Reads in our VERSION file and sticks in it CURRENT_VERSION variable
-# Be sure the file has no newlines!
-# This exposes CURRENT_VERSION to the build system
-# And it's later fed to JUCE so it shows up as VERSION in your IDE
-file(STRINGS VERSION CURRENT_VERSION)
+include_guard()
 
-# Figure out the major version to append to our PROJECT_NAME
-string(REGEX MATCH "([0-9]+)" MAJOR_VERSION ${CURRENT_VERSION})
-message(STATUS "Major version: ${MAJOR_VERSION}")
+# Read the version file and sets the version to the CURRENT_VERSION argument
+#
+# pjuce_read_version_file(FILE <file> CURRENT_VERSION)
+#
+# e.g.
+# pjuce_read_version_file(FILE "VERSION" CURRENT_VERSION)
+#
+# pjuce_read_version_file(CURRENT_VERSION) # defaults to "VERSION" file
+#
+function(pjuce_read_version_file CURRENT_VERSION)
+    cmake_parse_arguments(_PJ "" "FILE" "" ${ARGN})
+
+    if(NOT _PJ_FILE)
+        set(_PJ_FILE "VERSION")
+    endif()
+
+    # Reads in our VERSION file and sticks in it CURRENT_VERSION variable
+    # Be sure the file has no newlines!
+    # This exposes CURRENT_VERSION to the build system
+    # And it's later fed to JUCE so it shows up as VERSION in your IDE
+    file(STRINGS ${_PJ_FILE} _CURRENT_VERSION)
+
+    # Figure out the major version to append to our PROJECT_NAME
+    string(REGEX MATCH "([0-9]+)" MAJOR_VERSION ${_CURRENT_VERSION})
+    message(STATUS "Major version: ${MAJOR_VERSION}")
+
+    set(${CURRENT_VERSION} ${_CURRENT_VERSION} PARENT_SCOPE)
+endfunction()

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ endif()
 
 # Add pj_cmake_includes from https://github.com/sudara/cmake-includes
 # Change the version in the following URL to update the package (watch the releases of the repository for future updates)
-set(PJ_CMAKE_INCLUDES_VERSION "51546407b32258e3b6b907c24d4b80116b1edec6")
+set(PJ_CMAKE_INCLUDES_VERSION "e4cb35e39b1ee0bb0060105ab1be959cff22d1c8")
 FetchContent_Declare(
-  _pj_cmake_includes
-  URL https://github.com/sudara/cmake-includes/archive/refs/tags/${PJ_CMAKE_INCLUDES_VERSION}.zip)
+  _pamblejuce_cmake
+  URL https://github.com/aminya/cmake-includes/archive/${PJ_CMAKE_INCLUDES_VERSION}.zip)
 FetchContent_MakeAvailable(_pj_cmake_includes)
 include(${_pj_cmake_includes_SOURCE_DIR}/Index.cmake)
 ```

--- a/README.md
+++ b/README.md
@@ -6,27 +6,63 @@ Hi there!
 
 It's most of the actual CMake functionality used by [Pamplejuce](https://github.com/sudara/pamplejuce), my template repository for plugins in the JUCE framework.
 
-## Why is this its own git submodule?
+## How to include in your project
 
-It's to help projects built by the template pull in the lastest changes.
+```cmake
+cmake_minimum_required(VERSION 3.20)
+
+include(FetchContent)
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")
+  cmake_policy(SET CMP0135 NEW)
+endif()
+
+# Add pj_cmake_includes from https://github.com/sudara/cmake-includes
+# Change the version in the following URL to update the package (watch the releases of the repository for future updates)
+set(PJ_CMAKE_INCLUDES_VERSION "51546407b32258e3b6b907c24d4b80116b1edec6")
+FetchContent_Declare(
+  _pj_cmake_includes
+  URL https://github.com/sudara/cmake-includes/archive/refs/tags/${PJ_CMAKE_INCLUDES_VERSION}.zip)
+FetchContent_MakeAvailable(_pj_cmake_includes)
+include(${_pj_cmake_includes_SOURCE_DIR}/Index.cmake)
+```
+
+## List Of Functions/Macros
+
+Here are the functions/macros you can use. For full documentation of each see the respective files.
+
+- `pjuce_add_assets`
+- `pjuce_add_benchmark`
+- `pjuce_ci_write_env_file`
+- `pjuce_add_defaults`
+- `pjuce_link_ipp`
+- `pjuce_add_macos_defaults`
+- `pjuce_read_version_file`
+- `pjuce_add_shared_target_defaults`
+- `pjuce_add_tests`
+- `pjuce_xcode_pretty`
+
+
+## Why is this its own CMake library
+
+It's to help projects built by the template in the lastest changes.
 
 [Pamplejuce](https://github.com/sudara/pamplejuce) is a template repository. Unlike most "dependencies," when you hit "Create Template" you are literally copying and pasting the code. Which sorta sucks, as people can't get fixes or updates.
 
 ## Why would I want updates?
 
-For at least the gritty CMake details, there are fixes, improvements and additional functionality being added. 
+For at least the gritty CMake details, there are fixes, improvements and additional functionality being added.
 
-In the best case, as a submodule, you can pull in the fixes and improvements.
+In the best case, as a library, you can update in the fixes and improvements.
 
 In the worst case, this seperate repo will help you see what exactly changed in Pamplejuce.
 
 ## Is it risky?
 
-It could be! 
+It could be!
 
 As of 2023, Pamplejuce is still being changed around a bunch, with the goal of being a better and better ecosystem for developers.
 
-That means there could be breakage when you pull. 
+That means there could be breakage when you update.
 
 ## What changed recently tho?
 

--- a/SharedCodeDefaults.cmake
+++ b/SharedCodeDefaults.cmake
@@ -1,19 +1,31 @@
-# fast math and better simd support in RELEASE and RELWITHDEBINFO
-if (MSVC)
-    # https://learn.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-170#fast
-    target_compile_options(SharedCode INTERFACE $<$<CONFIG:RELEASE>:/fp:fast>)
-else ()
-    # See the implications here:
-    # https://stackoverflow.com/q/45685487
-    target_compile_options(SharedCode INTERFACE $<$<CONFIG:RELEASE>:-Ofast>)
-    target_compile_options(SharedCode INTERFACE $<$<CONFIG:RelWithDebInfo>:-Ofast>)
-endif ()
+include_guard()
 
-# Tell MSVC to properly report what c++ version is being used
-if (MSVC)
-    target_compile_options(SharedCode INTERFACE /Zc:__cplusplus)
-endif ()
+# Add the defaults for the shared code target
+# It enables C++20, fast math and better simd support in RELEASE and RELWITHDEBINFO
+#
+# pjuce_add_shared_target_defaults(target)
+#
+# e.g.
+# pjuce_add_shared_target_defaults(SharedCode)
+#
+function(pjuce_add_shared_target_defaults target)
+    # fast math and better simd support in RELEASE and RELWITHDEBINFO
+    if (MSVC)
+        # https://learn.microsoft.com/en-us/cpp/build/reference/fp-specify-floating-point-behavior?view=msvc-170#fast
+        target_compile_options(${target} INTERFACE $<$<CONFIG:RELEASE>:/fp:fast>)
+    else ()
+        # See the implications here:
+        # https://stackoverflow.com/q/45685487
+        target_compile_options(${target} INTERFACE $<$<CONFIG:RELEASE>:-Ofast>)
+        target_compile_options(${target} INTERFACE $<$<CONFIG:RelWithDebInfo>:-Ofast>)
+    endif ()
 
-# C++20, please
-# Use cxx_std_23 for C++23 (as of CMake v 3.20)
-target_compile_features(SharedCode INTERFACE cxx_std_20)
+    # Tell MSVC to properly report what c++ version is being used
+    if (MSVC)
+        target_compile_options(${target} INTERFACE /Zc:__cplusplus)
+    endif ()
+
+    # C++20, please
+    # Use cxx_std_23 for C++23 (as of CMake v 3.20)
+    target_compile_features(${target} INTERFACE cxx_std_20)
+endfunction()

--- a/Tests.cmake
+++ b/Tests.cmake
@@ -1,53 +1,83 @@
-# Required for ctest (which is just an easier way to run in cross-platform CI)
-# include(CTest) could be used too, but adds additional targets we don't care about
-# See: https://github.com/catchorg/Catch2/issues/2026
-# You can also forgo ctest entirely and call ./Tests directly from the build dir
-enable_testing()
+include_guard()
 
-# Go into detail when there's a CTest failure
-set(CTEST_OUTPUT_ON_FAILURE ON)
-set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
+# Define a test target with the given sources and Catch2
+#
+# pjuce_add_tests(
+#     target
+#     [DIR dir]
+#     SOURCES <sources...>
+#     INCLUDES <includes...>
+#     DEPENDS <depends...>
+# )
+#
+# e.g.
+# pjuce_add_tests(
+#     Tests
+#     DIR ./tests
+#     SOURCES ./tests/*.cpp ./tests/*.h
+#     INCLUDES ${CMAKE_CURRENT_SOURCE_DIR}/../Source
+#     DEPENDS SharedCode
+# )
+macro(pjuce_add_tests target)
+    set(_oneValueArgs DIR)
+    set(_multiValueArgs SOURCES INCLUDES DEPENDS)
+    cmake_parse_arguments(_PJ "" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
 
-# "GLOBS ARE BAD" is brittle and silly dev UX, sorry CMake!
-file(GLOB_RECURSE TestFiles CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.h")
+    if (NOT _PJ_DIR)
+        set(_PJ_DIR ${CMAKE_CURRENT_SOURCE_DIR}/tests)
+    endif()
 
-# Organize the test source in the Tests/ folder in Xcode
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/tests PREFIX "" FILES ${TestFiles})
+    # Required for ctest (which is just an easier way to run in cross-platform CI)
+    # include(CTest) could be used too, but adds additional targets we don't care about
+    # See: https://github.com/catchorg/Catch2/issues/2026
+    # You can also forgo ctest entirely and call ./Tests directly from the build dir
+    enable_testing()
 
-# Use Catch2 v3 on the devel branch
-Include(FetchContent)
-FetchContent_Declare(
-    Catch2
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_PROGRESS TRUE
-    GIT_SHALLOW TRUE
-    GIT_TAG v3.4.0)
-FetchContent_MakeAvailable(Catch2) # find_package equivalent
+    # Go into detail when there's a CTest failure
+    set(CTEST_OUTPUT_ON_FAILURE ON)
+    set_property(GLOBAL PROPERTY CTEST_TARGETS_ADDED 1)
 
-# Setup the test executable, again C++20 please
-add_executable(Tests ${TestFiles})
-target_compile_features(Tests PRIVATE cxx_std_20)
+    # "GLOBS ARE BAD" is brittle and silly dev UX, sorry CMake!
+    file(GLOB_RECURSE TestFiles CONFIGURE_DEPENDS ${_PJ_SOURCES})
 
-# Our test executable also wants to know about our plugin code...
-target_include_directories(Tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/source)
+    # Organize the test source in the Tests/ folder in Xcode
+    source_group(TREE ${_PJ_DIR} PREFIX "" FILES ${TestFiles})
 
-# Copy over compile definitions from our plugin target so it has all the JUCEy goodness
-target_compile_definitions(Tests PRIVATE $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
+    # Use Catch2 v3 on the devel branch
+    Include(FetchContent)
+    FetchContent_Declare(
+        Catch2
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_PROGRESS TRUE
+        GIT_SHALLOW TRUE
+        GIT_TAG v3.4.0)
+    FetchContent_MakeAvailable(Catch2) # find_package equivalent
 
-# And give tests access to our shared code
-target_link_libraries(Tests PRIVATE SharedCode Catch2::Catch2WithMain)
+    # Setup the test executable, again C++20 please
+    add_executable(${target} ${TestFiles})
+    target_compile_features(${target} PRIVATE cxx_std_20)
 
-# Make an Xcode Scheme for the test executable so we can run tests in the IDE
-set_target_properties(Tests PROPERTIES XCODE_GENERATE_SCHEME ON)
+    # Our test executable also wants to know about our plugin code...
+    target_include_directories(${target} PRIVATE ${_PJ_INCLUDES})
 
-# When running Tests we have specific needs
-target_compile_definitions(Tests PUBLIC
-    JUCE_MODAL_LOOPS_PERMITTED=1 # let us run Message Manager in tests
-    RUN_PAMPLEJUCE_TESTS=1 # also run tests in other module .cpp files guarded by RUN_PAMPLEJUCE_TESTS
-)
+    # Copy over compile definitions from our plugin target so it has all the JUCEy goodness
+    target_compile_definitions(${target} PRIVATE $<TARGET_PROPERTY:${PROJECT_NAME},COMPILE_DEFINITIONS>)
 
-# Load and use the .cmake file provided by Catch2
-# https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md
-# We have to manually provide the source directory here for now
-include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
-catch_discover_tests(Tests)
+    # And give tests access to our shared code
+    target_link_libraries(${target} PRIVATE ${_PJ_DEPENDS} Catch2::Catch2WithMain)
+
+    # Make an Xcode Scheme for the test executable so we can run tests in the IDE
+    set_target_properties(${target} PROPERTIES XCODE_GENERATE_SCHEME ON)
+
+    # When running tests we have specific needs
+    target_compile_definitions(${target} PUBLIC
+        JUCE_MODAL_LOOPS_PERMITTED=1 # let us run Message Manager in tests
+        RUN_PAMPLEJUCE_TESTS=1 # also run tests in other module .cpp files guarded by RUN_PAMPLEJUCE_TESTS
+    )
+
+    # Load and use the .cmake file provided by Catch2
+    # https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md
+    # We have to manually provide the source directory here for now
+    include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
+    catch_discover_tests(${target})
+endmacro()

--- a/XcodePrettify.cmake
+++ b/XcodePrettify.cmake
@@ -1,31 +1,65 @@
-# No, we don't want our source buried in extra nested folders
-set_target_properties(SharedCode PROPERTIES FOLDER "")
+include_guard()
 
-# The Xcode source tree should uhhh, still look like the source tree, yo
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/source PREFIX "" FILES ${SourceFiles})
+# Make the target pretty in Xcode
+#
+# pjuce_xcode_pretty(
+#     source_target
+#     ASSET_TARGET asset_target
+#     DIR dir
+#     SOURCES source1 source2 ...
+#     AudioPluginHostPath path
+# )
+#
+# e.g.
+# pjuce_xcode_pretty(
+#     SharedCode
+#     DIR ${CMAKE_CURRENT_SOURCE_DIR}/Source
+#     SOURCES
+#         ${CMAKE_CURRENT_SOURCE_DIR}/Source/*.cpp
+#         ${CMAKE_CURRENT_SOURCE_DIR}/Source/*.h
+# )
+#
+# AudioPluginHostPath defaults to ${CMAKE_CURRENT_SOURCE_DIR}/JUCE/extras/AudioPluginHost/Builds/MacOSX/build/Debug/AudioPluginHost.app"
+function(pjuce_xcode_pretty source_target)
+    set(_oneValueArgs DIR ASSET_TARGET _PJ_AUDIOPLUGINHOSTPATH)
+    set(_multiValueArgs SOURCES)
+    cmake_parse_arguments(_PJ "" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
 
-# It tucks the Plugin varieties into a "Targets" folder and generate an Xcode Scheme manually
-# Xcode scheme generation is turned off globally to limit noise from other targets
-# The non-hacky way of doing this is via the global PREDEFINED_TARGETS_FOLDER property
-# However that doesn't seem to be working in Xcode
-# Not all plugin types (au, vst) available on each build type (win, macos, linux)
-foreach (target ${FORMATS} "All")
-    if (TARGET ${PROJECT_NAME}_${target})
-        set_target_properties(${PROJECT_NAME}_${target} PROPERTIES
-            # Tuck the actual plugin targets into a folder where they won't bother us
-            FOLDER "Targets"
-            # Let us build the target in Xcode
-            XCODE_GENERATE_SCHEME ON)
-
-        # Set the default executable that Xcode will open on build
-        # Note: you must manually build the AudioPluginHost.xcodeproj in the JUCE subdir
-        if ((NOT target STREQUAL "All") AND (NOT target STREQUAL "Standalone"))
-            set_target_properties(${PROJECT_NAME}_${target} PROPERTIES
-                XCODE_SCHEME_EXECUTABLE "${CMAKE_CURRENT_SOURCE_DIR}/JUCE/extras/AudioPluginHost/Builds/MacOSX/build/Debug/AudioPluginHost.app")
-        endif ()
+    if (NOT _PJ_AUDIOPLUGINHOSTPATH)
+        set(_PJ_AUDIOPLUGINHOSTPATH "${CMAKE_CURRENT_SOURCE_DIR}/JUCE/extras/AudioPluginHost/Builds/MacOSX/build/Debug/AudioPluginHost.app")
     endif ()
-endforeach ()
 
-if (TARGET Assets)
-    set_target_properties(Assets PROPERTIES FOLDER "Targets")
-endif ()
+    if (NOT _PJ_ASSET_TARGET AND TARGET Assets)
+        set(_PJ_ASSET_TARGET "Assets")
+    endif ()
+
+    # No, we don't want our source buried in extra nested folders
+    set_target_properties(${source_target} PROPERTIES FOLDER "")
+
+    # The Xcode source tree should uhhh, still look like the source tree, yo
+    source_group(TREE ${_PJ_DIR} PREFIX "" FILES ${_PJ_SOURCES})
+
+    # It tucks the Plugin varieties into a "Targets" folder and generate an Xcode Scheme manually
+    # Xcode scheme generation is turned off globally to limit noise from other targets
+    # The non-hacky way of doing this is via the global PREDEFINED_TARGETS_FOLDER property
+    # However that doesn't seem to be working in Xcode
+    # Not all plugin types (au, vst) available on each build type (win, macos, linux)
+    foreach (target ${FORMATS} "All")
+        if (TARGET ${PROJECT_NAME}_${target})
+            set_target_properties(${PROJECT_NAME}_${target} PROPERTIES
+                # Tuck the actual plugin targets into a folder where they won't bother us
+                FOLDER "Targets"
+                # Let us build the target in Xcode
+                XCODE_GENERATE_SCHEME ON)
+
+            # Set the default executable that Xcode will open on build
+            # Note: you must manually build the AudioPluginHost.xcodeproj in the JUCE subdir
+            if ((NOT target STREQUAL "All") AND (NOT target STREQUAL "Standalone"))
+                set_target_properties(${PROJECT_NAME}_${target} PROPERTIES
+                    XCODE_SCHEME_EXECUTABLE ${_PJ_AUDIOPLUGINHOSTPATH})
+            endif ()
+        endif ()
+    endforeach ()
+
+    set_target_properties(${_PJ_ASSET_TARGET} PROPERTIES FOLDER "Targets")
+endfunction()


### PR DESCRIPTION
This allows configuring various parameters of the includes through function/macro arguments (e.g. target names, paths, etc.).

This is a breaking change as now the function/macros should be called. 

Tip for the review: hide the whitespace changes from the GitHub UI!