### PR TITLE
Xcode / arm64 bug fix

### DIFF
--- a/Tests.cmake
+++ b/Tests.cmake
@@ -50,4 +50,6 @@ target_compile_definitions(Tests PUBLIC
 # https://github.com/catchorg/Catch2/blob/devel/docs/cmake-integration.md
 # We have to manually provide the source directory here for now
 include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
-catch_discover_tests(Tests)
+# ${DISCOVERY_MODE} set to "PRE_TEST" for MacOS arm64 / Xcode development
+# fixes error when Xcode attempts to run test executable
+catch_discover_tests(Tests ${DISCOVERY_MODE} "PRE_TEST")


### PR DESCRIPTION
Without `catch_discover_tests` argument `DISCOVERY_MODE` being set to "PRE_TEST" Xcode attempts to run the test executable before signing it, which won't work on apple arm64 machines