### PR TITLE
Fix CI failure of iOS builds

### DIFF
--- a/PamplejuceMacOS.cmake
+++ b/PamplejuceMacOS.cmake
@@ -6,7 +6,7 @@ set(CMAKE_OSX_DEPLOYMENT_TARGET "10.13" CACHE STRING "Support macOS down to High
 
 # Building universal binaries on macOS increases build time
 # This is set on CI but not during local dev
-if ((DEFINED ENV{CI}) AND (CMAKE_BUILD_TYPE STREQUAL "Release"))
+if ((DEFINED ENV{CI}) AND (CMAKE_BUILD_TYPE STREQUAL "Release") AND NOT (CMAKE_SYSTEM_NAME STREQUAL "iOS"))
     message("Building for Apple Silicon and x86_64")
     set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
 endif ()


### PR DESCRIPTION
The platform should be checked here, otherwise compilation on CI will fail with unsupported platform error, if the plugin is being built for iOS.