### PR TITLE
fixed a cmake error when the 'Assets' folder is empty

### DIFF
--- a/Assets.cmake
+++ b/Assets.cmake
@@ -4,8 +4,13 @@ file(GLOB_RECURSE AssetFiles CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/asse
 list (FILTER AssetFiles EXCLUDE REGEX "/\\.DS_Store$") # We don't want the .DS_Store on macOS though...
 
 # Setup our binary data as a target called Assets
-juce_add_binary_data(Assets SOURCES ${AssetFiles})
+if (NOT AssetFiles STREQUAL "")
+    juce_add_binary_data(Assets SOURCES ${AssetFiles})
 
-# Required for Linux happiness:
-# See https://forum.juce.com/t/loading-pytorch-model-using-binarydata/39997/2
-set_target_properties(Assets PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+    # Required for Linux happiness:
+    # See https://forum.juce.com/t/loading-pytorch-model-using-binarydata/39997/2
+    set_target_properties(Assets PROPERTIES POSITION_INDEPENDENT_CODE TRUE)
+
+else()
+    message(STATUS "No assets found to add to the binary data")
+endif()


### PR DESCRIPTION
This fixes a cmake error when the `Assets/` folder is empty.
To reproduce, clone pamplejuce, init submodules, delete the content of the Assets folder and run `cmake -B Builds/macOS -G Xcode`:

>  CMake Error at JUCE/extras/Build/CMake/JUCEUtils.cmake:442 (message):
>    juce_add_binary_data must be passed at least one file to encode
>  Call Stack (most recent call first):
>    cmake/Assets.cmake:7 (juce_add_binary_data)
>    CMakeLists.txt:100 (include)
