### PR TITLE
Update XcodePrettify so that if you have external files that are outside of your source tree then they do not cause cmake to error

### DIFF
--- a/XcodePrettify.cmake
+++ b/XcodePrettify.cmake
@@ -1,8 +1,28 @@
 # No, we don't want our source buried in extra nested folders
 set_target_properties(SharedCode PROPERTIES FOLDER "")
 
-# The Xcode source tree should uhhh, still look like the source tree, yo
-source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/source PREFIX "" FILES ${SourceFiles})
+# Separate SourceFiles into two groups:
+# 1. Files under ${CMAKE_CURRENT_SOURCE_DIR}/source
+# 2. Files outside ${CMAKE_CURRENT_SOURCE_DIR}/source
+set(SourceFilesInTree "")
+set(SourceFilesOutOfTree "")
+foreach(file ${SourceFiles})
+    if(file MATCHES "^${CMAKE_CURRENT_SOURCE_DIR}/source")
+        list(APPEND SourceFilesInTree ${file})
+    else()
+        list(APPEND SourceFilesOutOfTree ${file})
+    endif()
+endforeach()
+
+# Apply source_group only to files under ${CMAKE_CURRENT_SOURCE_DIR}/source
+if(SourceFilesInTree)
+    source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/source PREFIX "" FILES ${SourceFilesInTree})
+endif()
+
+# Optionally, create a separate group for files outside the source directory
+if(SourceFilesOutOfTree)
+    source_group("External Files" FILES ${SourceFilesOutOfTree})
+endif()
 
 # It tucks the Plugin varieties into a "Targets" folder and generate an Xcode Scheme manually
 # Xcode scheme generation is turned off globally to limit noise from other targets


### PR DESCRIPTION
I don't normally have external files but if you are using something that requires an external file adding to the `SourceFiles` in cmake.  I recently encountered this when using the pace SDK on Windows.  The external file causes XcorePrettify to output an error that the external file does not have the correct prefix.