### PR TITLE
Fix DISCOVERY_MODE syntax and make Benchmarks also PRE_TEST for Mac

### DIFF
--- a/Benchmarks.cmake
+++ b/Benchmarks.cmake
@@ -5,7 +5,7 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR}/benchmarks PREFIX "" FILES ${Bench
 
 add_executable(Benchmarks ${BenchmarkFiles})
 target_compile_features(Benchmarks PRIVATE cxx_std_20)
-catch_discover_tests(Benchmarks)
+catch_discover_tests(Benchmarks DISCOVERY_MODE "PRE_TEST")
 
 # Our benchmark executable also wants to know about our plugin code...
 target_include_directories(Benchmarks PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/source)

--- a/Tests.cmake
+++ b/Tests.cmake
@@ -59,6 +59,6 @@ endif ()
 # We have to manually provide the source directory here for now
 include(${Catch2_SOURCE_DIR}/extras/Catch.cmake)
 
-# ${DISCOVERY_MODE} set to "PRE_TEST" for MacOS arm64 / Xcode development
+# DISCOVERY_MODE set to "PRE_TEST" for MacOS arm64 / Xcode development
 # fixes error when Xcode attempts to run test executable
-catch_discover_tests(Tests ${DISCOVERY_MODE} "PRE_TEST")
+catch_discover_tests(Tests DISCOVERY_MODE "PRE_TEST")


### PR DESCRIPTION
Correct me if I'm wrong but DISCOVERY_MODE shouldn't be a variable. Also Benchmarks needs to be discovered PRE_TEST to work on Mac. Just tested with Pamplejuce now.